### PR TITLE
#47 対応しました

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -4,7 +4,7 @@ import store from './store.js'
 import Mypage from './views/Mypage.vue'
 import Search from './views/Search.vue'
 import Login from './views/Login.vue'
-// import Auth from './services/auth.js'
+import Auth from './services/auth.js'
 
 Vue.use(Router)
 
@@ -45,9 +45,9 @@ var router = new Router({
 router.beforeEach((to, from, next) => {
   var loggedIn = store.state.loggedIn
   if (to.matched.some(record => !record.meta.isPublic) && !loggedIn) {
-    // if (Auth.isLoggedin()) {
-    //   store.commit('login')
-    // }
+    if (Auth.isLoggedin()) {
+      store.commit('login')
+    }
     next({ path: '/login' })
   } else if (to.path === '/login' && loggedIn) {
     next({ path: '/' })


### PR DESCRIPTION
# エラー原因と対応
元々のエラーは **cognitoIdentity.sessionがnullの状態でgetRefreshToken()を呼び出してしまっている** ことにありました。
このためリロード時に明示的にsessionを取得、 cognitoIdentity.sessionに格納してやる必要があります。

## UI
routerを修正し、セッションストレージに必要な値が格納されていればログイン状態とみなすよう変更を行いました。

## Service
src/services/auth.jsを更新しました。

### reload関数の作成
これはAWSのJavascript SDKのサイトから[現在のユーザーの取得方法](https://docs.aws.amazon.com/ja_jp/cognito/latest/developerguide/using-amazon-cognito-user-identity-pools-javascript-examples.html#using-amazon-cognito-user-identity-pools-javascript-examples-get-user-from-local-storage)をコピーして作成した関数になります。

* user pool id
* client id

を指定したストレージに保持している場合、セッションを取得することが可能です。
これを利用し、userやsessionなどの各種情報を取得、cognitoIdentityオブジェクトに格納します。

### refreshAuth関数の修正
cognitoIdentity.sessionがnullであることを判定し、reload関数を呼び出します。
